### PR TITLE
Added platform addon support

### DIFF
--- a/anno-state-machine-android/src/main/java/com/jayway/annostatemachine/Addons.java
+++ b/anno-state-machine-android/src/main/java/com/jayway/annostatemachine/Addons.java
@@ -1,0 +1,20 @@
+package com.jayway.annostatemachine;
+
+
+import com.jayway.annostatemachine.android.AndroidAddon;
+
+import java.util.ArrayList;
+
+public class Addons implements AddonRepo {
+
+    private ArrayList<FrameworkAddon> mAddons = new ArrayList<>();
+
+    public Addons() {
+        mAddons.add(new AndroidAddon());
+    }
+
+    @Override
+    public ArrayList<FrameworkAddon> getAddons() {
+        return mAddons;
+    }
+}

--- a/anno-state-machine-android/src/main/java/com/jayway/annostatemachine/android/AndroidAddon.java
+++ b/anno-state-machine-android/src/main/java/com/jayway/annostatemachine/android/AndroidAddon.java
@@ -1,0 +1,15 @@
+package com.jayway.annostatemachine.android;
+
+
+import com.jayway.annostatemachine.AnnoStateMachine;
+import com.jayway.annostatemachine.FrameworkAddon;
+import com.jayway.annostatemachine.android.util.LogcatStateMachineLogger;
+
+public class AndroidAddon implements FrameworkAddon {
+    private static final String TAG = AndroidAddon.class.getSimpleName();
+
+    @Override
+    public void init() {
+        AnnoStateMachine.setLogger(new LogcatStateMachineLogger());
+    }
+}

--- a/anno-state-machine-android/src/main/java/com/jayway/annostatemachine/android/util/LogcatStateMachineLogger.java
+++ b/anno-state-machine-android/src/main/java/com/jayway/annostatemachine/android/util/LogcatStateMachineLogger.java
@@ -1,0 +1,28 @@
+package com.jayway.annostatemachine.android.util;
+
+import android.util.Log;
+
+import com.jayway.annostatemachine.utils.StateMachineLogger;
+
+public class LogcatStateMachineLogger implements StateMachineLogger {
+
+    @Override
+    public void e(String tag, String msg) {
+        Log.e(tag, msg);
+    }
+
+    @Override
+    public void e(String tag, String msg, Throwable t) {
+        Log.e(tag, msg, t);
+    }
+
+    @Override
+    public void d(String tag, String msg) {
+        Log.d(tag, msg);
+    }
+
+    @Override
+    public void w(String tag, String msg) {
+        Log.w(tag, msg);
+    }
+}

--- a/anno-state-machine/src/main/java/com/jayway/annostatemachine/AddonRepo.java
+++ b/anno-state-machine/src/main/java/com/jayway/annostatemachine/AddonRepo.java
@@ -1,0 +1,9 @@
+package com.jayway.annostatemachine;
+
+
+import java.util.ArrayList;
+
+public interface AddonRepo {
+
+    ArrayList<FrameworkAddon> getAddons();
+}

--- a/anno-state-machine/src/main/java/com/jayway/annostatemachine/Config.java
+++ b/anno-state-machine/src/main/java/com/jayway/annostatemachine/Config.java
@@ -1,0 +1,58 @@
+package com.jayway.annostatemachine;
+
+
+import com.jayway.annostatemachine.utils.StateMachineLogger;
+import com.jayway.annostatemachine.utils.SystemOutLogger;
+
+import java.util.ArrayList;
+
+public class Config {
+
+    private static Config sInstance;
+
+    private StateMachineLogger mLogger;
+
+    public static Config get() {
+        if (sInstance == null) {
+            sInstance = new Config();
+            sInstance.init();
+        }
+        return sInstance;
+    }
+
+    private void init() {
+        // Platform specific versions will create a class named Addons in which platform specific
+        // addons are listed. However, it is done in the platform lib so we have to use reflection
+        // to get it.
+
+        // If more than one Addon is present it's important not to modify the same static fields such
+        // as the logger set in the AnnoStateMachine class
+        try {
+            Class clazz = Config.class.getClassLoader().loadClass("com.jayway.annostatemachine.Addons");
+            AddonRepo repo = (AddonRepo) clazz.newInstance();
+            ArrayList<FrameworkAddon> addons = repo.getAddons();
+            if (addons == null) {
+                return;
+            }
+            for (FrameworkAddon addon : addons) {
+                addon.init();
+            }
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        collectDependencies();
+    }
+
+    private void collectDependencies() {
+        mLogger = AnnoStateMachine.getLogger();
+    }
+
+    public StateMachineLogger getLogger() {
+        return mLogger;
+    }
+
+    void setLoggerForTest(StateMachineLogger logger) {
+        mLogger = logger;
+    }
+}

--- a/anno-state-machine/src/main/java/com/jayway/annostatemachine/FrameworkAddon.java
+++ b/anno-state-machine/src/main/java/com/jayway/annostatemachine/FrameworkAddon.java
@@ -1,0 +1,8 @@
+package com.jayway.annostatemachine;
+
+/**
+ * An addon to the state machine generation framework.
+ */
+public interface FrameworkAddon {
+    void init();
+}

--- a/anno-state-machine/src/main/java/com/jayway/annostatemachine/processor/StateMachineCreator.java
+++ b/anno-state-machine/src/main/java/com/jayway/annostatemachine/processor/StateMachineCreator.java
@@ -18,6 +18,7 @@ package com.jayway.annostatemachine.processor;
 
 
 import com.jayway.annostatemachine.AnnoStateMachine;
+import com.jayway.annostatemachine.Config;
 import com.jayway.annostatemachine.ConnectionRef;
 import com.jayway.annostatemachine.DispatchCallback;
 import com.jayway.annostatemachine.NoOpMainThreadPoster;
@@ -93,7 +94,7 @@ final class StateMachineCreator {
         javaWriter.emitField(StateMachineEventListener.class.getSimpleName(), "mEventListener", EnumSet.of(Modifier.PRIVATE));
         javaWriter.emitField(SignalDispatcher.class.getSimpleName(), "mSignalDispatcher", EnumSet.of(Modifier.PRIVATE));
         javaWriter.emitField(DispatchCallback.class.getSimpleName(), "mDispatchCallback", EnumSet.of(Modifier.PRIVATE));
-        javaWriter.emitField(StateMachineLogger.class.getSimpleName(), "mLogger", EnumSet.of(Modifier.PRIVATE), "AnnoStateMachine.getLogger()");
+        javaWriter.emitField(StateMachineLogger.class.getSimpleName(), "mLogger", EnumSet.of(Modifier.PRIVATE), "Config.get().getLogger()");
         javaWriter.emitField(MainThreadPoster.class.getSimpleName(), "mMainThreadPoster", EnumSet.of(Modifier.PRIVATE), "new NoOpMainThreadPoster()");
         javaWriter.emitField(AtomicBoolean.class.getSimpleName(), "mIsShutdown", EnumSet.of(Modifier.PRIVATE), "new AtomicBoolean(false)");
         javaWriter.emitField("int", "mSharedId");
@@ -205,7 +206,7 @@ final class StateMachineCreator {
                         SignalDispatcher.class.getCanonicalName(),
                         DispatchCallback.class.getCanonicalName(),
                         StateMachineLogger.class.getCanonicalName(),
-                        AnnoStateMachine.class.getCanonicalName(),
+                        Config.class.getCanonicalName(),
                         NoOpMainThreadPoster.class.getCanonicalName(),
                         MainThreadPoster.class.getCanonicalName(),
                         Callable.class.getCanonicalName(),

--- a/app/src/main/java/com/jayway/annostatemachine/MainActivity.java
+++ b/app/src/main/java/com/jayway/annostatemachine/MainActivity.java
@@ -33,7 +33,6 @@ import com.jayway.annostatemachine.annotations.Signals;
 import com.jayway.annostatemachine.annotations.StateMachine;
 import com.jayway.annostatemachine.annotations.States;
 import com.jayway.annostatemachine.generated.MainViewStateMachineImpl;
-import com.jayway.annostatemachine.utils.StateMachineLogger;
 
 import static com.jayway.annostatemachine.MainActivity.MainViewStateMachine.KEY_CHECKBOX_CHECKED;
 import static com.jayway.annostatemachine.MainActivity.MainViewStateMachine.Signal.CheckBoxCheckStateChanged;
@@ -54,28 +53,6 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        AnnoStateMachine.setLogger(new StateMachineLogger() {
-            @Override
-            public void e(String tag, String msg) {
-                Log.e(tag, msg);
-            }
-
-            @Override
-            public void e(String tag, String msg, Throwable t) {
-                Log.e(tag, msg, t);
-            }
-
-            @Override
-            public void d(String tag, String msg) {
-                Log.d(tag, msg);
-            }
-
-            @Override
-            public void w(String tag, String msg) {
-                Log.w(tag, msg);
-            }
-        });
-
         mStateMachine = new MainViewStateMachineImpl(this);
         mStateMachine.init(MainViewStateMachine.State.Init, new StateMachineEventListener() {
             @Override
@@ -95,7 +72,6 @@ public class MainActivity extends AppCompatActivity {
         onClick(findViewById(R.id.nextButton), mStateMachine, Next);
 
         mStateMachine.send(Start, null);
-
         loadContentAsync(mStateMachine);
     }
 

--- a/app/src/test/java/com/jayway/annostatemachine/TestHelper.java
+++ b/app/src/test/java/com/jayway/annostatemachine/TestHelper.java
@@ -1,0 +1,14 @@
+package com.jayway.annostatemachine;
+
+import com.jayway.annostatemachine.utils.StateMachineLogger;
+
+
+/**
+ * Helper class that helps with calling package private methods that should be hid from clients but
+ * not from the framework itself.
+ */
+public class TestHelper {
+    public static void setLoggerForTest(StateMachineLogger logger) {
+        Config.get().setLoggerForTest(logger);
+    }
+}

--- a/app/src/test/java/com/jayway/annostatemachine/dispatchertests/ShutdownTests.java
+++ b/app/src/test/java/com/jayway/annostatemachine/dispatchertests/ShutdownTests.java
@@ -17,13 +17,17 @@
 package com.jayway.annostatemachine.dispatchertests;
 
 
+import com.jayway.annostatemachine.Config;
 import com.jayway.annostatemachine.SignalPayload;
+import com.jayway.annostatemachine.TestHelper;
 import com.jayway.annostatemachine.annotations.Connection;
 import com.jayway.annostatemachine.annotations.Signals;
 import com.jayway.annostatemachine.annotations.StateMachine;
 import com.jayway.annostatemachine.annotations.States;
 import com.jayway.annostatemachine.dispatchertests.generated.MachineImpl;
+import com.jayway.annostatemachine.utils.SystemOutLogger;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
@@ -35,6 +39,11 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ShutdownTests {
+
+    @Before
+    public void setUp() {
+        TestHelper.setLoggerForTest(new SystemOutLogger());
+    }
 
     @Test
     public void testSignalIgnoredAfterStateMachineShutDown() {


### PR DESCRIPTION
The Android lib now sets an Android specific logger instance.

If a platform specific lib has addons it must create an Addons.java
file in the com.jayway.annostatemachine package and inherit AddonRepo.

If such a file exists it will be loaded and the addons that it exposes
will be initialized. This happens when the first state machine
implementation class is intantiated and calls Config.get().